### PR TITLE
Cambio en formularios de voluntariado

### DIFF
--- a/src/modules/volunteer/models/volunteer_options.model.ts
+++ b/src/modules/volunteer/models/volunteer_options.model.ts
@@ -161,8 +161,8 @@ export const updateVolunteerOption = async (id: number, option: Omit<VolunteerOp
 
 // Delete a volunteer option
 export const deleteVolunteerOption = async (id: number): Promise<void> => {
-  // First, update any volunteers that reference this option to set volunteer_option_id to NULL
-  await db.query('UPDATE volunteers SET volunteer_option_id = NULL WHERE volunteer_option_id = ?', [id]);
+  // First, delete all volunteers associated with this option
+  await db.query('DELETE FROM volunteers WHERE volunteer_option_id = ?', [id]);
   // Then delete the option
   await db.query('DELETE FROM volunteer_options WHERE id = ?', [id]);
 };


### PR DESCRIPTION
Anteriormente al eliminar un voluntariado, los voluntarios no se eliminaban, sino que se quedaban sin asignar, y solo se podia eliminar mediante la base de dato.
Con este cambio, al eliminar el voluntariado, automaticamente se eliminaran tambien los voluntarios.